### PR TITLE
Jovin/command sequences

### DIFF
--- a/src/main/java/frc/robot/commands/DeepClimbPrep.java
+++ b/src/main/java/frc/robot/commands/DeepClimbPrep.java
@@ -1,0 +1,16 @@
+package frc.robot.commands;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+import frc.robot.subsystems.climb.Climb;
+import frc.robot.subsystems.climb.Climb.ClimbPosition;
+
+public class DeepClimbPrep extends SequentialCommandGroup {
+    public DeepClimbPrep(Climb climb) {
+      addRequirements(climb);
+      // TODO use apriltag to allign with cage
+      addCommands(
+        new WaitUntilCommand(() -> climb.isClimbMovable()),
+        new InstantCommand(() -> climb.setDesiredClimbPosition(ClimbPosition.CLIMBING_PREP)));
+    }
+  }


### PR DESCRIPTION
Preliminary version of deep climb prep command sequence. Checks if it can and then moves the arm to the desired position. Wasn't able to implement april tag integration due to the lack of its implementation.